### PR TITLE
NM-1277 | Extended support to include Token along the msg

### DIFF
--- a/lib/fluent/plugin/formatter_syslog_rfc5424.rb
+++ b/lib/fluent/plugin/formatter_syslog_rfc5424.rb
@@ -23,9 +23,11 @@ module Fluent
         @log_field_array = @log_field.split(".")
       end
 
-      def format(tag, time, record)
+      def format(tag, time, record, token = nil)
         log.debug("Record")
         log.debug(record.map { |k, v| "#{k}=#{v}" }.join('&'))
+
+        structured_data = token.nil? nil: RFC5424::StructuredData.new(sd_id: token).to_s
 
         msg = RFC5424::Formatter.format(
           log: record.dig(*@log_field_array) || "-",
@@ -34,7 +36,7 @@ module Fluent
           app_name: record.dig(*@app_name_field_array) || "-",
           proc_id: record.dig(*@proc_id_field_array) || "-",
           msg_id: record.dig(*@message_id_field_array) || "-",
-          sd: record.dig(*@structured_data_field_array) || "-"
+          sd: structured_data || record.dig(*@structured_data_field_array) || "-"
         )
 
         log.debug("RFC 5424 Message")

--- a/lib/fluent/plugin/out_syslog_rfc5424.rb
+++ b/lib/fluent/plugin/out_syslog_rfc5424.rb
@@ -13,6 +13,7 @@ module Fluent
       config_param :transport, :string, default: "tls"
       config_param :insecure, :bool, default: false
       config_param :trusted_ca_path, :string, default: nil
+      config_param :token, :string, default: nil
       config_section :format do
         config_set_default :@type, DEFAULT_FORMATTER
       end
@@ -32,7 +33,7 @@ module Fluent
         tag = chunk.metadata.tag
         chunk.each do |time, record|
           begin
-            socket.write_nonblock @formatter.format(tag, time, record)
+            socket.write_nonblock @formatter.format(tag, time, record, @token)
             IO.select(nil, [socket], nil, 1) || raise(StandardError.new "ReconnectError")
           rescue => e
             @sockets.delete(socket_key(@transport.to_sym, @host, @port))


### PR DESCRIPTION
Added support for including a token which can be used for Sumo using structured data. Any data in **Structured Data** is converted to string and appended to the end of the message string. 

The PR will add **[TOKEN]** into the message object. This is based of on the REPO: https://github.com/acquia/fluent-plugin-sumologic-cloud-syslog/ 