### PR TITLE
NM-1312 |  Update syslog plugin to accept token value as structured data

### DIFF
--- a/lib/fluent/plugin/formatter_syslog_rfc5424.rb
+++ b/lib/fluent/plugin/formatter_syslog_rfc5424.rb
@@ -40,9 +40,7 @@ module Fluent
         log.debug("RFC 5424 Message")
         log.debug(msg)
 
-        return msg + "\n" unless @rfc6587_message_size
-
-        msg.length.to_s + ' ' + msg
+        return msg
       end
     end
   end

--- a/lib/fluent/plugin/formatter_syslog_rfc5424.rb
+++ b/lib/fluent/plugin/formatter_syslog_rfc5424.rb
@@ -34,7 +34,7 @@ module Fluent
           app_name: record.dig(*@app_name_field_array) || "-",
           proc_id: record.dig(*@proc_id_field_array) || "-",
           msg_id: record.dig(*@message_id_field_array) || "-",
-          sd: record.dig(*@structured_data_field_array) || "-"
+          sd: RFC5424::StructuredData.new(sd_id: record.dig(*@structured_data_field_array)).to_s || "-"
         )
 
         log.debug("RFC 5424 Message")

--- a/lib/fluent/plugin/formatter_syslog_rfc5424.rb
+++ b/lib/fluent/plugin/formatter_syslog_rfc5424.rb
@@ -40,7 +40,9 @@ module Fluent
         log.debug("RFC 5424 Message")
         log.debug(msg)
 
-        return msg
+        return msg + "\n" unless @rfc6587_message_size
+
+        msg.length.to_s + ' ' + msg
       end
     end
   end

--- a/lib/fluent/plugin/formatter_syslog_rfc5424.rb
+++ b/lib/fluent/plugin/formatter_syslog_rfc5424.rb
@@ -33,7 +33,7 @@ module Fluent
           app_name: record.dig(*@app_name_field_array) || "-",
           proc_id: record.dig(*@proc_id_field_array) || "-",
           msg_id: record.dig(*@message_id_field_array) || "-",
-          sd: get_structured_data(record)
+          sd: parse_structured_data(record)
         )
 
         log.debug("RFC 5424 Message")
@@ -44,10 +44,10 @@ module Fluent
         msg.length.to_s + ' ' + msg
       end
 
-      def get_structured_data(record)
+      def parse_structured_data(record)
         sd_array = []
         @structured_data_field_array.each do |sd_field|
-          sd_array << RFC5424::StructuredData.new(sd_id: record.dig(sd_field) ).to_s if record.dig(sd_field)
+          sd_array << RFC5424::StructuredData.new(sd_id: record.dig(sd_field)).to_s if record.dig(sd_field)
         end
         return sd_array.empty? ? '-' : sd_array.join('')
       end

--- a/lib/fluent/plugin/formatter_syslog_rfc5424.rb
+++ b/lib/fluent/plugin/formatter_syslog_rfc5424.rb
@@ -25,11 +25,7 @@ module Fluent
 
       def format(tag, time, record)
         log.debug("Record")
-        sd_array = []
         log.debug(record.map { |k, v| "#{k}=#{v}" }.join('&'))
-        @structured_data_field_array.each do |sd|
-          sd_array << RFC5424::StructuredData.new(sd_id: sd).to_s
-        end
         msg = RFC5424::Formatter.format(
           log: record.dig(*@log_field_array) || "-",
           timestamp: time,
@@ -53,7 +49,7 @@ module Fluent
         @structured_data_field_array.each do |sd_field|
           sd_array << RFC5424::StructuredData.new(sd_id: record.dig(sd_field) ).to_s if record.dig(sd_field)
         end
-        return sd_array.empty? ? "-" : sd_array.join("")
+        return sd_array.empty? ? '-' : sd_array.join('')
       end
     end
   end

--- a/lib/fluent/plugin/formatter_syslog_rfc5424.rb
+++ b/lib/fluent/plugin/formatter_syslog_rfc5424.rb
@@ -26,6 +26,7 @@ module Fluent
       def format(tag, time, record)
         log.debug("Record")
         log.debug(record.map { |k, v| "#{k}=#{v}" }.join('&'))
+
         msg = RFC5424::Formatter.format(
           log: record.dig(*@log_field_array) || "-",
           timestamp: time,

--- a/lib/rfc5424/formatter.rb
+++ b/lib/rfc5424/formatter.rb
@@ -2,7 +2,7 @@ require 'date'
 
 module RFC5424
   class Formatter
-    Format = "<%d>1 %s %s %s %s %s [%s] %s"
+    Format = "<%d>1 %s %s %s %s %s %s %s"
 
     class << self
       def format(

--- a/lib/rfc5424/formatter.rb
+++ b/lib/rfc5424/formatter.rb
@@ -6,7 +6,7 @@ module RFC5424
 
     class << self
       def format(
-        priority: 133,
+        priority: 14,
         timestamp: nil,
         log: "",
         hostname: "-",

--- a/lib/rfc5424/formatter.rb
+++ b/lib/rfc5424/formatter.rb
@@ -2,7 +2,7 @@ require 'date'
 
 module RFC5424
   class Formatter
-    Format = "<%d>1 %s %s %s %s %s %s %s"
+    Format = "<%d>1 %s %s %s %s %s [%s] %s"
 
     class << self
       def format(

--- a/lib/rfc5424/formatter.rb
+++ b/lib/rfc5424/formatter.rb
@@ -6,7 +6,7 @@ module RFC5424
 
     class << self
       def format(
-        priority: 14,
+        priority: 133,
         timestamp: nil,
         log: "",
         hostname: "-",

--- a/test/plugin/formatter_syslog_rfc5424_spec.rb
+++ b/test/plugin/formatter_syslog_rfc5424_spec.rb
@@ -18,7 +18,7 @@ class FormatterSyslogRFC5424Test < Test::Unit::TestCase
     tag = "test-formatter"
     time = Fluent::EventTime.new(0, 123456000)
     record = {"log" => "test-log"}
-    assert_equal "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - - test-log\n",
+    assert_equal "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - [] test-log\n",
                  formatter_driver.instance.format(tag, time, record)
   end
 
@@ -30,7 +30,7 @@ class FormatterSyslogRFC5424Test < Test::Unit::TestCase
     tag = "test-formatter"
     time = Fluent::EventTime.new(0, 123456000)
     record = {"log" => "test-log"}
-    assert_equal "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - - test-log\n",
+    assert_equal "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - [] test-log\n",
                  formatter_driver.instance.format(tag, time, record)
   end
 
@@ -43,7 +43,7 @@ class FormatterSyslogRFC5424Test < Test::Unit::TestCase
     time = Fluent::EventTime.new(0, 123456000)
     record = {"log" => "test-log"}
 
-    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - - test-log"
+    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - [] test-log"
     message_size = formatted_message.length
     assert_equal "#{message_size} #{formatted_message}",
                  formatter_driver.instance.format(tag, time, record)
@@ -59,7 +59,7 @@ class FormatterSyslogRFC5424Test < Test::Unit::TestCase
     time = Fluent::EventTime.new(0, 123456000)
     record = {"log" => "test-log", "example" => {"custom_field" => "custom-value"}}
 
-    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - custom-value - - - test-log\n"
+    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - custom-value - - [] test-log\n"
     message_size = formatted_message.length
     assert_equal "#{formatted_message}",
                  formatter_driver.instance.format(tag, time, record)
@@ -75,7 +75,7 @@ class FormatterSyslogRFC5424Test < Test::Unit::TestCase
     time = Fluent::EventTime.new(0, 123456000)
     record = {"log" => "test-log", "example" => {"custom_field" => "custom-value"}}
 
-    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - - custom-value\n"
+    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - [] custom-value\n"
     message_size = formatted_message.length
     assert_equal "#{formatted_message}",
                  formatter_driver.instance.format(tag, time, record)
@@ -91,7 +91,7 @@ class FormatterSyslogRFC5424Test < Test::Unit::TestCase
     time = Fluent::EventTime.new(0, 123456000)
     record = {"log" => "test-log", "example" => {"custom_field" => "custom-value"}}
 
-    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - custom-value test-log\n"
+    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - [custom-value] test-log\n"
     message_size = formatted_message.length
     assert_equal "#{formatted_message}",
                  formatter_driver.instance.format(tag, time, record)
@@ -107,7 +107,7 @@ class FormatterSyslogRFC5424Test < Test::Unit::TestCase
     time = Fluent::EventTime.new(0, 123456000)
     record = {"log" => "test-log", "example" => {"custom_field" => "custom-value"}}
 
-    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 custom-value - - - - test-log\n"
+    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 custom-value - - - [] test-log\n"
     message_size = formatted_message.length
     assert_equal "#{formatted_message}",
                  formatter_driver.instance.format(tag, time, record)
@@ -123,7 +123,7 @@ class FormatterSyslogRFC5424Test < Test::Unit::TestCase
     time = Fluent::EventTime.new(0, 123456000)
     record = {"log" => "test-log", "example" => {"custom_field" => "custom-value"}}
 
-    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - custom-value - - test-log\n"
+    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - custom-value - [] test-log\n"
     message_size = formatted_message.length
     assert_equal "#{formatted_message}",
                  formatter_driver.instance.format(tag, time, record)
@@ -139,7 +139,7 @@ class FormatterSyslogRFC5424Test < Test::Unit::TestCase
     time = Fluent::EventTime.new(0, 123456000)
     record = {"log" => "test-log", "example" => {"custom_field" => "custom-value"}}
 
-    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - - custom-value - test-log\n"
+    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - - custom-value [] test-log\n"
     message_size = formatted_message.length
     assert_equal "#{formatted_message}",
                  formatter_driver.instance.format(tag, time, record)

--- a/test/plugin/formatter_syslog_rfc5424_spec.rb
+++ b/test/plugin/formatter_syslog_rfc5424_spec.rb
@@ -18,7 +18,7 @@ class FormatterSyslogRFC5424Test < Test::Unit::TestCase
     tag = "test-formatter"
     time = Fluent::EventTime.new(0, 123456000)
     record = {"log" => "test-log"}
-    assert_equal "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - [] test-log\n",
+    assert_equal "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - - test-log\n",
                  formatter_driver.instance.format(tag, time, record)
   end
 
@@ -30,7 +30,7 @@ class FormatterSyslogRFC5424Test < Test::Unit::TestCase
     tag = "test-formatter"
     time = Fluent::EventTime.new(0, 123456000)
     record = {"log" => "test-log"}
-    assert_equal "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - [] test-log\n",
+    assert_equal "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - - test-log\n",
                  formatter_driver.instance.format(tag, time, record)
   end
 
@@ -43,7 +43,7 @@ class FormatterSyslogRFC5424Test < Test::Unit::TestCase
     time = Fluent::EventTime.new(0, 123456000)
     record = {"log" => "test-log"}
 
-    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - [] test-log"
+    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - - test-log"
     message_size = formatted_message.length
     assert_equal "#{message_size} #{formatted_message}",
                  formatter_driver.instance.format(tag, time, record)
@@ -59,7 +59,7 @@ class FormatterSyslogRFC5424Test < Test::Unit::TestCase
     time = Fluent::EventTime.new(0, 123456000)
     record = {"log" => "test-log", "example" => {"custom_field" => "custom-value"}}
 
-    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - custom-value - - [] test-log\n"
+    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - custom-value - - - test-log\n"
     message_size = formatted_message.length
     assert_equal "#{formatted_message}",
                  formatter_driver.instance.format(tag, time, record)
@@ -75,7 +75,7 @@ class FormatterSyslogRFC5424Test < Test::Unit::TestCase
     time = Fluent::EventTime.new(0, 123456000)
     record = {"log" => "test-log", "example" => {"custom_field" => "custom-value"}}
 
-    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - [] custom-value\n"
+    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - - custom-value\n"
     message_size = formatted_message.length
     assert_equal "#{formatted_message}",
                  formatter_driver.instance.format(tag, time, record)
@@ -85,13 +85,29 @@ class FormatterSyslogRFC5424Test < Test::Unit::TestCase
     formatter_driver = create_driver %(
       @type syslog_rfc5424
       rfc6587_message_size false
-      structured_data_field example.custom_field
+      structured_data_field custom-field
     )
     tag = "test-formatter"
     time = Fluent::EventTime.new(0, 123456000)
-    record = {"log" => "test-log", "example" => {"custom_field" => "custom-value"}}
+    record = {"log" => "test-log", "custom-field" => "custom-value"}
 
     formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - [custom-value] test-log\n"
+    message_size = formatted_message.length
+    assert_equal "#{formatted_message}",
+                 formatter_driver.instance.format(tag, time, record)
+  end
+
+  def test_format_with_multiple_structured_data_field
+    formatter_driver = create_driver %(
+      @type syslog_rfc5424
+      rfc6587_message_size false
+      structured_data_field custom-field1.custom-field2.custom-field3
+    )
+    tag = "test-formatter"
+    time = Fluent::EventTime.new(0, 123456000)
+    record = {"log" => "test-log", "custom-field1" => "custom-value1", "custom-field2" => "custom-value2", "custom-field3" => "custom-value3"}
+
+    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - - - [custom-value1][custom-value2][custom-value3] test-log\n"
     message_size = formatted_message.length
     assert_equal "#{formatted_message}",
                  formatter_driver.instance.format(tag, time, record)
@@ -107,7 +123,7 @@ class FormatterSyslogRFC5424Test < Test::Unit::TestCase
     time = Fluent::EventTime.new(0, 123456000)
     record = {"log" => "test-log", "example" => {"custom_field" => "custom-value"}}
 
-    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 custom-value - - - [] test-log\n"
+    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 custom-value - - - - test-log\n"
     message_size = formatted_message.length
     assert_equal "#{formatted_message}",
                  formatter_driver.instance.format(tag, time, record)
@@ -123,7 +139,7 @@ class FormatterSyslogRFC5424Test < Test::Unit::TestCase
     time = Fluent::EventTime.new(0, 123456000)
     record = {"log" => "test-log", "example" => {"custom_field" => "custom-value"}}
 
-    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - custom-value - [] test-log\n"
+    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - custom-value - - test-log\n"
     message_size = formatted_message.length
     assert_equal "#{formatted_message}",
                  formatter_driver.instance.format(tag, time, record)
@@ -139,7 +155,7 @@ class FormatterSyslogRFC5424Test < Test::Unit::TestCase
     time = Fluent::EventTime.new(0, 123456000)
     record = {"log" => "test-log", "example" => {"custom_field" => "custom-value"}}
 
-    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - - custom-value [] test-log\n"
+    formatted_message = "<14>1 1970-01-01T00:00:00.123456+00:00 - - - custom-value - test-log\n"
     message_size = formatted_message.length
     assert_equal "#{formatted_message}",
                  formatter_driver.instance.format(tag, time, record)

--- a/test/plugin/out_syslog_rfc5424_spec.rb
+++ b/test/plugin/out_syslog_rfc5424_spec.rb
@@ -37,7 +37,7 @@ class OutSyslogRFC5424Test < Test::Unit::TestCase
     stub(IO).select(nil, [socket], nil, 1) { ["not an error"] }
 
     any_instance_of(Fluent::Plugin::OutSyslogRFC5424) do |fluent_plugin|
-      mock(fluent_plugin).socket_create(:tls, "example.com", 123, {:insecure=>false, :verify_fqdn=>true, :cert_paths=>nil, :cert_path=>nil, :private_key_path=>nil, :private_key_passphrase=>nil, :allow_self_signed_cert=>false, :enable_system_cert_store=>true, :fqdn=>nil, :version=>"TLSv1_2"}).returns(socket)
+      mock(fluent_plugin).socket_create(:tls, "example.com", 123, {:insecure=>false, :verify_fqdn=>true, :cert_paths=>[nil], :cert_path=>nil, :private_key_path=>nil, :private_key_passphrase=>nil, :allow_self_signed_cert=>false, :enable_system_cert_store=>true, :fqdn=>nil, :version=>:TLSv1_2}).returns(socket)
     end
 
     output_driver.run do
@@ -64,8 +64,8 @@ class OutSyslogRFC5424Test < Test::Unit::TestCase
     mock(IO).select(nil, [good_socket], nil, 1) { ["not an error"] }
 
     any_instance_of(Fluent::Plugin::OutSyslogRFC5424) do |fluent_plugin|
-      mock(fluent_plugin).socket_create(:tls, "example.com", 123, {:insecure=>false, :verify_fqdn=>true, :cert_paths=>nil, :cert_path=>nil, :private_key_path=>nil, :private_key_passphrase=>nil, :allow_self_signed_cert=>false, :enable_system_cert_store=>true, :fqdn=>nil, :version=>"TLSv1_2"}).returns(bad_socket)
-      mock(fluent_plugin).socket_create(:tls, "example.com", 123, {:insecure=>false, :verify_fqdn=>true, :cert_paths=>nil, :cert_path=>nil, :private_key_path=>nil, :private_key_passphrase=>nil, :allow_self_signed_cert=>false, :enable_system_cert_store=>true, :fqdn=>nil, :version=>"TLSv1_2"}).returns(good_socket)
+      mock(fluent_plugin).socket_create(:tls, "example.com", 123, {:insecure=>false, :verify_fqdn=>true, :cert_paths=>[nil], :cert_path=>nil, :private_key_path=>nil, :private_key_passphrase=>nil, :allow_self_signed_cert=>false, :enable_system_cert_store=>true, :fqdn=>nil, :version=>:TLSv1_2}).returns(bad_socket)
+      mock(fluent_plugin).socket_create(:tls, "example.com", 123, {:insecure=>false, :verify_fqdn=>true, :cert_paths=>[nil], :cert_path=>nil, :private_key_path=>nil, :private_key_passphrase=>nil, :allow_self_signed_cert=>false, :enable_system_cert_store=>true, :fqdn=>nil, :version=>:TLSv1_2}).returns(good_socket)
     end
 
     output_driver.run(shutdown: false, force_flush_retry: true) do
@@ -112,7 +112,7 @@ class OutSyslogRFC5424Test < Test::Unit::TestCase
     stub(IO).select(nil, [socket], nil, 1) { ["not an error"] }
 
     any_instance_of(Fluent::Plugin::OutSyslogRFC5424) do |fluent_plugin|
-      mock(fluent_plugin).socket_create(:tls, "example.com", 123, {:insecure=>true, :verify_fqdn=>false, :cert_paths=>nil, :cert_path=>nil, :private_key_path=>nil, :private_key_passphrase=>nil, :allow_self_signed_cert=>false, :enable_system_cert_store=>true, :fqdn=>nil, :version=>"TLSv1_2"}).returns(socket)
+      mock(fluent_plugin).socket_create(:tls, "example.com", 123, {:insecure=>true, :verify_fqdn=>false, :cert_paths=>[nil], :cert_path=>nil, :private_key_path=>nil, :private_key_passphrase=>nil, :allow_self_signed_cert=>false, :enable_system_cert_store=>true, :fqdn=>nil, :version=>:TLSv1_2}).returns(socket)
     end
 
     output_driver.run do
@@ -136,7 +136,7 @@ class OutSyslogRFC5424Test < Test::Unit::TestCase
     stub(IO).select(nil, [socket], nil, 1) { ["not an error"] }
 
     any_instance_of(Fluent::Plugin::OutSyslogRFC5424) do |fluent_plugin|
-      mock(fluent_plugin).socket_create(:tls, "example.com", 123, {:insecure=>false, :verify_fqdn=>true, :cert_paths=>"supertrustworthy", :cert_path=>nil, :private_key_path=>nil, :private_key_passphrase=>nil, :allow_self_signed_cert=>false, :enable_system_cert_store=>true, :fqdn=>nil, :version=>"TLSv1_2"}).returns(socket)
+      mock(fluent_plugin).socket_create(:tls, "example.com", 123, {:insecure=>false, :verify_fqdn=>true, :cert_paths=>["supertrustworthy"], :cert_path=>nil, :private_key_path=>nil, :private_key_passphrase=>nil, :allow_self_signed_cert=>false, :enable_system_cert_store=>true, :fqdn=>nil, :version=>:TLSv1_2}).returns(socket)
     end
 
     output_driver.run do
@@ -168,7 +168,7 @@ class OutSyslogRFC5424Test < Test::Unit::TestCase
     stub(IO).select(nil, [socket], nil, 1) { ["not an error"] }
 
     any_instance_of(Fluent::Plugin::OutSyslogRFC5424) do |fluent_plugin|
-      mock(fluent_plugin).socket_create(:tls, "example.com", 123, {:insecure=>false, :verify_fqdn=>true, :cert_paths=>"supertrustworthy", :cert_path=>"supertrustworthy", :private_key_path=>"clientsupertrustworthykey", :private_key_passphrase=>"clientsupertrustworthykey", :allow_self_signed_cert=>false,  :enable_system_cert_store=>true, :fqdn=>"supertrustworthyfqdn", :version=>"TLSv1_2"}).returns(socket)
+      mock(fluent_plugin).socket_create(:tls, "example.com", 123, {:insecure=>false, :verify_fqdn=>true, :cert_paths=>["supertrustworthy"], :cert_path=>"clientsupertrustworthykey", :private_key_path=>"clientsupertrustworthykey", :private_key_passphrase=>"clientsupertrustworthypassphrase", :allow_self_signed_cert=>false,  :enable_system_cert_store=>true, :fqdn=>"supertrustworthyfqdn", :version=>:TLSv1_2}).returns(socket)
     end
 
     output_driver.run do
@@ -190,7 +190,7 @@ class OutSyslogRFC5424Test < Test::Unit::TestCase
     stub(IO).select(nil, [socket], nil, 1) { ["not an error"] }
 
     any_instance_of(Fluent::Plugin::OutSyslogRFC5424) do |fluent_plugin|
-      mock(fluent_plugin).socket_create(:tls, "example.com", 123, {:insecure=>false, :verify_fqdn=>true, :cert_paths=>nil, :cert_path=>nil, :private_key_path=>nil, :private_key_passphrase=>nil, :allow_self_signed_cert=>false, :enable_system_cert_store=>true, :fqdn=>nil, :version=>"TLSv1_2"}).returns(socket)
+      mock(fluent_plugin).socket_create(:tls, "example.com", 123, {:insecure=>false, :verify_fqdn=>true, :cert_paths=>[nil], :cert_path=>nil, :private_key_path=>nil, :private_key_passphrase=>nil, :allow_self_signed_cert=>false, :enable_system_cert_store=>true, :fqdn=>nil, :version=>:TLSv1_2}).returns(socket)
     end
 
     output_driver.run do


### PR DESCRIPTION
get_structured_data method added in Formatter to set structured data in RFC 5424 message 

## Manual Review :
RFC5424 message with token : 
```
2022-02-22 14:29:10 +0000 [debug]: #0 [flow:sw34dev:flow-apache-165a4bd3-dca6-44dc-b187-73da6ca051d7:output:sw34dev:log-forwarding-output-165a4bd3-dca6-44dc-b187-73da6ca051d7] RFC 5424 Message
2022-02-22 14:29:10 +0000 [debug]: #0 [flow:sw34dev:flow-apache-165a4bd3-dca6-44dc-b187-73da6ca051d7:output:sw34dev:log-forwarding-output-165a4bd3-dca6-44dc-b187-73da6ca051d7] <14>1 2022-02-22T14:28:58.525610+00:00 - - - - [9e545c1b-7479-4fdf-963c-4d13dcda33d1@41058] 1.22.92.135 - - [22/Feb/2022:14:28:58 +0000] "GET /?id=LogglyLogs@2022 HTTP/1.1" 200 5701 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36" vhost=sw34dev.ngc-2.sites.ahdev.co host=sw34dev.ngc-2.sites.ahdev.co hosting_site=sw34dev pid=10 request_time=51186 forwarded_for="1.22.92.135, 10.170.143.177" request_id="v-c5ad1b04-93eb-11ec-98c7-12c7264893bf" location="-" 
```
### RFC5424 message without token : 
```
2022-02-23 08:29:51 +0000 [debug]: #0 [flow:sw35dev:flow-apache-7d84aff4-4465-4467-9371-c4b52e062ce7:output:sw35dev:log-forwarding-output-7d84aff4-4465-4467-9371-c4b52e062ce7] RFC 5424 Message
2022-02-23 08:29:51 +0000 [debug]: #0 [flow:sw35dev:flow-apache-7d84aff4-4465-4467-9371-c4b52e062ce7:output:sw35dev:log-forwarding-output-7d84aff4-4465-4467-9371-c4b52e062ce7] <14>1 2022-02-23T08:25:30.176700+00:00 - - - - - 1.22.92.135 - - [23/Feb/2022:08:25:30 +0000] "GET /?user=Acquia@2022 HTTP/1.1" 200 5697 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/98.0.4758.102 Safari/537.36" vhost=sw35dev.ngc-2.sites.ahdev.co host=sw35dev.ngc-2.sites.ahdev.co hosting_site=sw35dev pid=9 request_time=58068 forwarded_for="1.22.92.135, 10.170.52.136" request_id="v-294b94ce-9482-11ec-b750-12c7264893bf" location="-" 
```
Logs in loggly destination : 

<img width="1790" alt="Screenshot 2022-02-22 at 7 59 38 PM" src="https://user-images.githubusercontent.com/32439113/155153663-8927be08-a4fe-447c-a443-e110695a3a8d.png">
